### PR TITLE
Manage modular namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 **NEW:**
 **BREAKING:**
 -->
-
 <a name="0.1.0"></a>
 # 0.1.0 Manage modular namespace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 **BREAKING:**
 -->
 
+<a name="0.1.0"></a>
+# 0.1.0 Manage modular namespace
+
+**FIXED:**
+* Modular SDKs containing this release will coalesce into a shared global namespace, rather than colliding and overwriting one another, and will store a reference to legacy versions of keen-js when detected. This legacy version can be referenced with `Keen.legacyVersion`, or returned to the `Keen` namespace by calling `var ModularLibs = Keen.noConflict();`.
+
+
 <a name="0.0.2"></a>
 # 0.0.2 RequireJS fix
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,8 @@ gulp.task('default', ['build', 'connect', 'watch']);
 gulp.task('build', function(){
   return browserify({
       entries: './lib/index.js',
-      debug: true
+      debug: true,
+      standalone: 'Keen'
     })
     .bundle()
     .pipe(source('keen-core.js'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,8 +19,7 @@ gulp.task('default', ['build', 'connect', 'watch']);
 gulp.task('build', function(){
   return browserify({
       entries: './lib/index.js',
-      debug: true,
-      standalone: 'Keen'
+      debug: true
     })
     .bundle()
     .pipe(source('keen-core.js'))

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,19 +200,6 @@ var Emitter = require('component-emitter');
     }
   }
 
-  // Module Definitions
-  // --------------------
-
-  // Global
-  if (env) {
-    env.Keen = Client;
-  }
-
-  // CommonJS
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = Client;
-  }
-
-  /* RequireJS defintion not necessary */
+  module.exports = Client;
 
 }).call(this, typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {});

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@
     Client.emit('client', this);
   }
 
-  if (previousKeen && isUndefined(previousKeen.resources)) {
+  if (previousKeen && typeof previousKeen.resources === 'undefined') {
     Client.legacyVersion = previousKeen;
   }
 
@@ -58,7 +58,7 @@
 
   Client.extendLibrary = function(target, source) {
     var previous = previousKeen || source;
-    if (isDefined(previous)) {
+    if (typeof previous !== 'undefined') {
       each(previous, function(value, key) {
         if (typeof value === 'object') {
           target[key] = target[key] || {};
@@ -80,7 +80,7 @@
   };
 
   Client.noConflict = function(){
-    if (isDefined(env.Keen)) {
+    if (typeof env.Keen !== 'undefined') {
       env.Keen = Client.legacyVersion || previousKeen;
     }
     return Client;
@@ -107,7 +107,7 @@
     };
 
     // IE<10 request shim
-    if (isDefined(env.navigator) && isDefined(env.navigator.userAgent) && env.navigator.userAgent.indexOf('MSIE') > -1) {
+    if (typeof window !== 'undefined' && window.navigator.userAgent.indexOf('MSIE') > -1) {
       config.protocol = document.location.protocol.replace(':', '');
     }
 
@@ -187,7 +187,7 @@
   });
 
   function domReady(fn){
-    if (Client.loaded || isUndefined(document)) {
+    if (Client.loaded || typeof document === 'undefined') {
       fn();
       return;
     }
@@ -211,10 +211,6 @@
     else {
       fn();
     }
-  }
-
-  function isDefined(target){
-    return typeof target !== 'undefined';
   }
 
   function isUndefined(target) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,11 @@
-var each = require('./utils/each'),
-    extend = require('./utils/extend'),
-    parseParams = require('./utils/parse-params'),
-    serialize = require('./utils/serialize');
-
-var Emitter = require('component-emitter');
-
 (function(env){
-  var previousKeen = typeof env.Keen !== 'undefined' ? env.Keen : undefined;
+  var previousKeen = env.Keen || undefined;
+  var each = require('./utils/each'),
+      extend = require('./utils/extend'),
+      parseParams = require('./utils/parse-params'),
+      serialize = require('./utils/serialize');
+
+  var Emitter = require('component-emitter');
 
   function Client(props){
     if (this instanceof Client === false) {
@@ -22,26 +21,12 @@ var Emitter = require('component-emitter');
     Client.emit('client', this);
   }
 
-  Emitter(Client);
-  Emitter(Client.prototype);
-
-
-  // Store a copy of earlier versions
-  if (previousKeen && typeof previousKeen.resources === 'undefined') {
+  if (previousKeen && isUndefined(previousKeen.resources)) {
     Client.legacyVersion = previousKeen;
   }
 
-  // if (previousKeen) {
-  //   extend(Client, previousKeen);
-  //   if (typeof previousKeen.resources === 'object') {
-  //     // Extend namespace when modules are detected
-  //     extend(Client.prototype, previousKeen.prototype);
-  //   }
-  //   else {
-  //     // Store a copy of earlier versions
-  //     Client.legacyVersion = previousKeen;
-  //   }
-  // }
+  Emitter(Client);
+  Emitter(Client.prototype);
 
   extend(Client, {
     debug: false,
@@ -71,6 +56,23 @@ var Emitter = require('component-emitter');
     'serialize'   : serialize
   });
 
+  Client.extendLibrary = function(target, source) {
+    var previous = previousKeen || source;
+    if (isDefined(previous)) {
+      each(previous, function(value, key) {
+        if (typeof value === 'object') {
+          target[key] = target[key] || {};
+          extend(target[key], value);
+        }
+        else {
+          target[key] = target[key] || value;
+        }
+      });
+      extend(target.prototype, previous.prototype);
+    }
+    return target;
+  };
+
   Client.log = function(str){
     if (Client.debug && typeof console === 'object') {
       console.log('[Keen]', str);
@@ -78,7 +80,7 @@ var Emitter = require('component-emitter');
   };
 
   Client.noConflict = function(){
-    if (typeof env.Keen !== 'undefined') {
+    if (isDefined(env.Keen)) {
       env.Keen = Client.legacyVersion || previousKeen;
     }
     return Client;
@@ -105,7 +107,7 @@ var Emitter = require('component-emitter');
     };
 
     // IE<10 request shim
-    if (typeof window !== 'undefined' && window.navigator.userAgent.indexOf('MSIE') > -1) {
+    if (isDefined(env.navigator) && isDefined(env.navigator.userAgent) && env.navigator.userAgent.indexOf('MSIE') > -1) {
       config.protocol = document.location.protocol.replace(':', '');
     }
 
@@ -185,7 +187,7 @@ var Emitter = require('component-emitter');
   });
 
   function domReady(fn){
-    if (Client.loaded || typeof document === 'undefined') {
+    if (Client.loaded || isUndefined(document)) {
       fn();
       return;
     }
@@ -209,6 +211,14 @@ var Emitter = require('component-emitter');
     else {
       fn();
     }
+  }
+
+  function isDefined(target){
+    return typeof target !== 'undefined';
+  }
+
+  function isUndefined(target) {
+    return typeof target === 'undefined';
   }
 
   module.exports = Client;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,17 +25,23 @@ var Emitter = require('component-emitter');
   Emitter(Client);
   Emitter(Client.prototype);
 
-  if (previousKeen) {
-    extend(Client, previousKeen);
-    if (typeof previousKeen.resources === 'object') {
-      // Extend namespace when modules are detected
-      extend(Client.prototype, previousKeen.prototype);
-    }
-    else {
-      // Store a copy of earlier versions
-      Client.legacyVersion = previousKeen;
-    }
+
+  // Store a copy of earlier versions
+  if (previousKeen && typeof previousKeen.resources === 'undefined') {
+    Client.legacyVersion = previousKeen;
   }
+
+  // if (previousKeen) {
+  //   extend(Client, previousKeen);
+  //   if (typeof previousKeen.resources === 'object') {
+  //     // Extend namespace when modules are detected
+  //     extend(Client.prototype, previousKeen.prototype);
+  //   }
+  //   else {
+  //     // Store a copy of earlier versions
+  //     Client.legacyVersion = previousKeen;
+  //   }
+  // }
 
   extend(Client, {
     debug: false,
@@ -43,6 +49,9 @@ var Emitter = require('component-emitter');
     loaded: false,
     version: '__VERSION__'
   });
+
+  // Set or extend helpers
+  Client.helpers = Client.helpers || {};
 
   // Set or extend resources
   Client.resources = Client.resources || {};
@@ -69,7 +78,9 @@ var Emitter = require('component-emitter');
   };
 
   Client.noConflict = function(){
-    env.Keen = Client.legacyVersion || previousKeen;
+    if (typeof env.Keen !== 'undefined') {
+      env.Keen = Client.legacyVersion || previousKeen;
+    }
     return Client;
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var each = require('./utils/each'),
 var Emitter = require('component-emitter');
 
 (function(env){
-  var initialKeen = typeof env.Keen !== 'undefined' ? env.Keen : undefined;
+  var previousKeen = typeof env.Keen !== 'undefined' ? env.Keen : undefined;
 
   function Client(props){
     if (this instanceof Client === false) {
@@ -25,23 +25,41 @@ var Emitter = require('component-emitter');
   Emitter(Client);
   Emitter(Client.prototype);
 
+  if (previousKeen) {
+    extend(Client, previousKeen);
+    if (typeof previousKeen.resources === 'object') {
+      // Extend namespace when modules are detected
+      extend(Client.prototype, previousKeen.prototype);
+    }
+    else {
+      // Store a copy of earlier versions
+      Client.legacyVersion = previousKeen;
+    }
+  }
+
   extend(Client, {
     debug: false,
     enabled: true,
     loaded: false,
-    resources: {
-      'base'      : '{protocol}://{host}',
-      'version'   : '{protocol}://{host}/3.0',
-      'projects'  : '{protocol}://{host}/3.0/projects',
-      'projectId' : '{protocol}://{host}/3.0/projects/{projectId}'
-    },
-    utils: {
-      'each'        : each,
-      'extend'      : extend,
-      'parseParams' : parseParams,
-      'serialize'   : serialize
-    },
     version: '__VERSION__'
+  });
+
+  // Set or extend resources
+  Client.resources = Client.resources || {};
+  extend(Client.resources, {
+    'base'      : '{protocol}://{host}',
+    'version'   : '{protocol}://{host}/3.0',
+    'projects'  : '{protocol}://{host}/3.0/projects',
+    'projectId' : '{protocol}://{host}/3.0/projects/{projectId}'
+  });
+
+  // Set or extend utils
+  Client.utils = Client.utils || {};
+  extend(Client.utils, {
+    'each'        : each,
+    'extend'      : extend,
+    'parseParams' : parseParams,
+    'serialize'   : serialize
   });
 
   Client.log = function(str){
@@ -51,7 +69,7 @@ var Emitter = require('component-emitter');
   };
 
   Client.noConflict = function(){
-    env.Keen = initialKeen;
+    env.Keen = Client.legacyVersion || previousKeen;
     return Client;
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keen-core",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Core functionality powering Keen IO's modular JavaScript SDKs",
   "main": "lib/index.js",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -116,3 +116,37 @@ test('.url()', function(t){
 
   t.end();
 });
+
+test('.extendLibrary()', function(t){
+  var test = {
+    'boolean': true,
+    'function': function(){},
+    'number': 123,
+    'object': {
+      'nested': {
+        'value': 987
+      }
+    },
+    'string': 'some-string',
+    'prototype': {
+      'method': function(a, b){ return a + b; }
+    }
+  };
+  App.extendLibrary(App, test);
+  t.equal(App.boolean, test.boolean,
+    'Should return an inherited boolean');
+  t.equal(App.function, test.function,
+    'Should return an inherited function');
+  t.equal(App.number, test.number,
+    'Should return an inherited number');
+  t.equal(App.string, test.string,
+    'Should return an inherited string');
+  t.equal(App.object.nested.value, test.object.nested.value,
+    'Should return an inherited object');
+  t.equal(App.prototype.method, test.prototype.method,
+    'Should return an inherited prototype method');
+
+  var app = new App();
+  t.equal(app.method(1, 2), 3,
+    'Should return an appropriate value from the prototype method');
+});


### PR DESCRIPTION
## What does this PR do?

Modular SDKs containing this release will coalesce into a shared global namespace, rather than colliding and overwriting one another, and will store a reference to legacy versions of keen-js when detected. This legacy version can be referenced with `Keen.legacyVersion`, or returned to the `Keen` namespace by calling `var ModularLibs = Keen.noConflict();`.

`Keen.extendLibrary()` does the following:

```javascript
Client.extendLibrary = function(target, source) {
    var previous = previousKeen || source;
    if (typeof previous !== 'undefined') {
      each(previous, function(value, key) {
        if (typeof value === 'object') {
          target[key] = target[key] || {};
          extend(target[key], value);
        }
        else {
          target[key] = target[key] || value;
        }
      });
      extend(target.prototype, previous.prototype);
    }
    return target;
};
```

`Keen.noConflict()` has been updated to return this legacy copy when available:

``` javascript
var previousKeen = env.Keen || undefined;

// ...

if (previousKeen && typeof previousKeen.resources === 'undefined') {
  Client.legacyVersion = previousKeen;
}

// ...

Client.noConflict = function(){
  if (typeof env.Keen !== 'undefined') {
    env.Keen = Client.legacyVersion || previousKeen;
  }
  return Client;
};
```

_In this snippet `env` is a variable within the scope where `Client.noConflict` is defined._
