### PR TITLE
Fixes check for IE10 so it works in environments where window is defined, but not navigator or userAgent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,7 +109,7 @@
     };
 
     // IE<10 request shim
-    if (typeof window !== 'undefined' && window.navigator.userAgent.indexOf('MSIE') > -1) {
+    if (typeof window !== 'undefined' && window.navigator && window.navigator.userAgent && window.navigator.userAgent.indexOf('MSIE') > -1) {
       config.protocol = document.location.protocol.replace(':', '');
     }
 


### PR DESCRIPTION
As title states. Further details seems to be that e.g. React Native does expose a window object, just not the one you would expect from a browser. This should make the user agent check 100% fail-safe.